### PR TITLE
added kraken api, and removed it from cryptowatch

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -38,7 +38,7 @@ let markets = [
                         let marketPair = key.split(':');
                         let market = marketPair[0], pair = marketPair[1];
                         let indexOfBTC = pair.indexOf('btc');
-                        if (indexOfBTC > 0 && !pair.includes('future') && !market.includes('qryptos') && !market.includes('quoine') && !market.includes('poloniex')) {
+                        if (indexOfBTC > 0 && !pair.includes('future') && !market.includes('qryptos') && !market.includes('quoine') && !market.includes('poloniex') && !market.includes('kraken')) {
                             if(marketNames.indexOf(market) === -1 ){
                                 marketNames.push(market);
                                 console.log(marketNames);
@@ -223,6 +223,42 @@ let markets = [
             })
 		},
 	},
+	
+	{
+
+        marketName: 'kraken', // kraken has no one size fits all market summery so each pair has to be entered as param in GET - will need to add new coins as they are added to exchange
+        URL: 'https://api.kraken.com/0/public/Ticker?pair=DASHXBT,EOSXBT,GNOXBT,ETCXBT,ETHXBT,ICNXBT,LTCXBT,MLNXBT,REPXBT,XDGXBT,XLMXBT,XMRXBT,XRPXBT,ZECXBT', //URL To Fetch API From.
+        toBTCURL: false, //URL, if needed for an external bitcoin price api.
+        last: function (data, coin_prices) { //Get the last price of coins in JSON data
+            return new Promise(function (res, rej) {
+                try {
+                    for (let key in data.result) {
+                        let arr = key.match(/DASH|EOS|GNO|ETC|ETH|ICN|LTC|MLN|REP|XDG|XLM|XMR|XRP|ZEC/); // matching real names to weird kraken api coin pairs like "XETCXXBT" etc 
+                        let name = key;
+                        let matchedName = arr[0];
+                        if (matchedName === "XDG") { //kraken calls DOGE "XDG" for whatever reason
+                            let matchedName = "DOGE";
+                            var coinName = matchedName;
+                        } else {
+                            var coinName = matchedName;
+                        }
+
+                        if (!coin_prices[coinName]) coin_prices[coinName] = {};
+                        
+                        coin_prices[coinName].kraken = data.result[name].c[0];
+
+                    }
+                    res(coin_prices);
+
+                }
+                catch (err) {
+                    console.log(err);
+                    rej(err);
+                }
+
+            })
+        },
+    },
 
 ];
 


### PR DESCRIPTION
Unfortunately kraken doesn't really provide an overall market summery with price info as many other APIs do. This makes it necessary to include all the desired coinpairs in the URL. The "safest" way to do this would probably be to have a function in the kraken markets object that gets all the kraken asset pairs from the API, parses them out of the JSON, and then adds them to a URL and returns that. But that seems like a lot of code to write, and would only have the advantage of never having to worry about adding a coin pair manually when kraken adds one to the exchange - which may happen, maybe once or twice a year, tops?