### PR TITLE
Add bid/ask system for more accurate prices and add links to coin pairs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -237,7 +237,7 @@
 
 <script id="high-template" type="text/x-handlebars-template">
     <li class="coin-info-high " data-coin="{{coin}}" data-market1="{{market1}}" data-market2="{{market2}}">
-        <h1>Transfer <strong>{{coin}}</strong> from <strong>{{market1}}</strong> to <strong> {{market2}}</strong> for a
+        <h1>Transfer <strong>{{coin}}</strong> from <strong><a href="{{coinlink1}}">{{market1}}</a></strong> to <strong><a href="{{coinlink2}}">{{market2}}</a></strong> for a
             profit of
             <strong> {{diff}}%</strong></h1>
         <div class="coin">

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,15 +254,15 @@
         Remove this opportunity </a>
     </li>
     <li class="coin-info-low" data-coin="{{pair.coin}}" data-market1="{{pair.market1}}" data-market2="{{pair-market2}}">
-        <h1>sell for <strong>{{pair.coin}}</strong> and transfer back to <strong> {{pair.market2}}
-            ({{pair.diff}}%)</strong>
+        <h1>sell for <strong>{{pair.coin}}</strong> and transfer back to <strong><a href="{{coinlink1}}"> {{pair.market1}}
+            ({{pair.diff}}%)</a></strong>
         </h1>
         <div class="coin">
             <i class="cc-{{pair.coin}} {{pair.coin}} cc"> </i>
             <p class="coin-name">{{pair.coin}}</p>
             <p class="coin-prices">{{pair.diff}}%</p>
-            <p class="coin-markets"><a>{{pair.market1}}</a>: {{pair.market1price}}<span class="mBTC">mBTC</span> <i
-                    class="fa fa-long-arrow-right"></i> <a>{{pair.market2}}</a>: {{pair.market2price}}<span
+            <p class="coin-markets"><a>{{pair.market1}}</a>: {{pair.market2price}}<span class="mBTC">mBTC</span> <i
+                    class="fa fa-long-arrow-right"></i> <a>{{pair.market2}}</a>: {{pair.market1price}}<span
                     class="mBTC">mBTC</span>
             </p>
         </div>

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -237,12 +237,14 @@ $(window).load(function () {
                         pair: {
                             coin: data[pairIndex][0],
                             diff: ((data[pairIndex][1] - 1) * 100).toFixed(2),
-                            market2price: (data[pairIndex][2] * 1000).toPrecision(3),
-                            market2: data[pairIndex][5],
-                            market1price: (data[pairIndex][3] * 1000).toPrecision(3),
-                            market1: data[pairIndex][4],
+                            market1price: (data[pairIndex][2] * 1000).toPrecision(3),
+                            market2: data[pairIndex][4],
+                            market2price: (data[pairIndex][3] * 1000).toPrecision(3),
+                            market1: data[pairIndex][5],
                         },
-                        totalDiff: (((data[i][1] - 1) * 100) + ((data[pairIndex][1] - 1) * 100)).toFixed(2)
+                        totalDiff: (((data[i][1] - 1) * 100) + ((data[pairIndex][1] - 1) * 100)).toFixed(2),
+                        coinlink1: coinLinkBuilder(data[i][0],lowMarket),
+                        coinlink2: coinLinkBuilder(data[i][0],highMarket)
                     };
 
                     if (i === data.length - highestN) { //Add only the highest
@@ -289,6 +291,21 @@ $(window).load(function () {
 
     });
 
+    function coinLinkBuilder(coin, market){
+        var marketBaseLinks = {
+            poloniex: 'https://poloniex.com/exchange#btc_',
+            bittrex: 'https://bittrex.com/Market/Index?MarketName=BTC-',
+            btc38: 'http://www.btc38.com/trade_en.html?btc38_trade_coin_name=',
+            jubi: 'https://www.jubi.com/coin/',
+            cryptopia: 'https://www.cryptopia.co.nz/Exchange/?market=',
+            bleutrade: 'https://bleutrade.com/exchange/',
+            kraken: 'https://www.kraken.com/u/trade'
+        }
+        if(market.includes('cryptopia')) return marketBaseLinks[market]+coin+'_BTC';
+        else if(market.includes('bleutrade')) return marketBaseLinks[market]+coin+'/BTC';
+        else if(market.includes('kraken')) return marketBaseLinks[market];
+        else return marketBaseLinks[market]+coin;
+    }
 });
 
 

--- a/main.js
+++ b/main.js
@@ -76,17 +76,23 @@ function computePrices(data) {
                 if(coinNames.includes(coin) == false) coinNames.push(coin);
 
 
-            let arr = [];
+            let asks = [];
+            let bids = [];
                 for (let market in data[coin]) {
-                    arr.push([data[coin][market], market]);
+                    asks.push([data[coin][market].ask, market]);
+                    bids.push([data[coin][market].bid, market]);
                 }
-                arr.sort(function (a, b) {
+                asks.sort(function (a, b) {
                     return a[0] - b[0];
                 });
-                for (let i = 0; i < arr.length; i++) {
-                    for (let j = i + 1; j < arr.length; j++) {
-                        results.push([coin, arr[i][0] / arr[j][0], arr[i][0], arr[j][0], arr[i][1], arr[j][1] ], [coin, arr[j][0] / arr[i][0], arr[j][0], arr[i][0], arr[j][1], arr[i][1]]);
+                bids.sort(function(a,b){
+                    return b[0] - a[0];
+                });
+                for (let i = 0; i < asks.length; i++) {
+                    for (let j = i; j < asks.length; j++) {
+                        results.push([coin,bids[i][0]/asks[j][0],bids[i][0],asks[j][0],bids[i][1],asks[j][1] ]);
                     }
+                    
                 }
 
             }

--- a/settings.js
+++ b/settings.js
@@ -74,7 +74,10 @@ let markets = [
                         if(obj["MarketName"].includes('BTC-')) {
                             let coinName = obj["MarketName"].replace("BTC-", '');
                             if (!coin_prices[coinName]) coin_prices[coinName] = {};
-                            coin_prices[coinName].bittrex = obj.Last;
+                            coin_prices[coinName]['bittrex'] = {
+                                bid: obj.Bid,
+                                ask: obj.Ask
+                            }; 
                         }
                     }
                     res(coin_prices);
@@ -102,8 +105,10 @@ let markets = [
                         let coinName = key.toUpperCase();
                         let price = data[key]['ticker'].last;
                         if (!coin_prices[coinName]) coin_prices[coinName] = {};
-
-                        coin_prices[coinName]["btc38"] = data[key]['ticker'].last / priceOfBTC;
+                        coin_prices[coinName]['btc38'] = {
+                            bid: data[key]['ticker'].buy / priceOfBTC,
+                            ask: data[key]['ticker'].sell / priceOfBTC
+                        }; 
                     }
                     res(coin_prices);
                 }
@@ -130,8 +135,10 @@ let markets = [
                         let coinName = key.toUpperCase();
                         let price = data[key].last;
                         if (!coin_prices[coinName]) coin_prices[coinName] = {};
-
-                        coin_prices[coinName]["jubi"] = data[key].last / priceOfBTC;
+                        coin_prices[coinName]['jubi'] = {
+                            bid: data[key].buy / priceOfBTC,
+                            ask: data[key].sell / priceOfBTC
+                        }; 
                     }
                     res(coin_prices);
                 }
@@ -158,7 +165,10 @@ let markets = [
                         if(obj.includes('BTC_')&&obj!=="BTC_EMC2") {
                             let coinName = obj.replace("BTC_", '');
                             if (!coin_prices[coinName]) coin_prices[coinName] = {};
-                            coin_prices[coinName].poloniex = data[obj].last;
+                            coin_prices[coinName]['poloniex'] = {
+                                bid: data[obj].highestBid,
+                                ask: data[obj].lowestAsk
+                            }; 
                         }
                     }
                     res(coin_prices);
@@ -184,8 +194,11 @@ let markets = [
 					for (let obj of data.Data) {
 						if(obj["Label"].includes('/BTC')) {
 							let coinName = obj["Label"].replace("/BTC", '');
-							if (!coin_prices[coinName]) coin_prices[coinName] = {};
-							coin_prices[coinName].cryptopia = obj.LastPrice;
+                            if (!coin_prices[coinName]) coin_prices[coinName] = {};
+                            coin_prices[coinName]['cryptopia'] = {
+                                bid: obj.BidPrice,
+                                ask: obj.AskPrice
+                            }; 
                         }
                     }
                     res(coin_prices);
@@ -211,8 +224,11 @@ let markets = [
 					for (let obj of data.result) {
 						if(obj["MarketName"].includes('_BTC')) {
 							let coinName = obj["MarketName"].replace("_BTC", '');
-							if (!coin_prices[coinName]) coin_prices[coinName] = {};
-							coin_prices[coinName].bleutrade = obj.Last;
+                            if (!coin_prices[coinName]) coin_prices[coinName] = {};
+                            coin_prices[coinName]['bleutrade'] = {
+                                bid: obj.Bid,
+                                ask: obj.Ask
+                            };
                         }
                     }
                     res(coin_prices);
@@ -248,9 +264,10 @@ let markets = [
                         }
 
                         if (!coin_prices[coinName]) coin_prices[coinName] = {};
-                        
-                        coin_prices[coinName].kraken = data.result[name].c[0];
-
+                        coin_prices[coinName]['kraken'] = {
+                            bid: data.result[name].b[0],
+                            ask: data.result[name].a[0]
+                        }; 
                     }
                     res(coin_prices);
 


### PR DESCRIPTION
Should resolve #13 because now we have accurate market data of what we actually can do it for.
Also should resolve #11 by adding links to each pair where it lists the market name. Let me know if I should change the location of these links.
Also I fixed a little error in the section of the "Sell for" part, where it would list them backwards.